### PR TITLE
Fix Vitest coverage setup for Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Run coverage
+        run: npm run coverage
+
       - name: Check coverage file exists
-        run: ls -R coverage || true
+        run: ls -R coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -10,12 +10,40 @@ const supabaseMockPath = path.resolve(
   "tests/mocks/supabaseMock.js"
 );
 
+function supabaseCdnMockPlugin() {
+  return {
+    name: "supabase-cdn-mock-plugin",
+    enforce: "pre",
+
+    resolveId(source) {
+      if (
+        source.startsWith(
+          "https://cdn.jsdelivr.net/npm/@supabase/supabase-js"
+        ) ||
+        source.startsWith("https://esm.sh/@supabase/supabase-js")
+      ) {
+        return supabaseMockPath;
+      }
+
+      return null;
+    },
+  };
+}
+
 export default defineConfig({
+  plugins: [supabaseCdnMockPlugin()],
+
   test: {
     environment: "jsdom",
     globals: true,
     clearMocks: true,
     restoreMocks: true,
+
+    coverage: {
+      provider: "istanbul",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "coverage",
+    },
   },
 
   resolve: {


### PR DESCRIPTION
This PR fixes the GitHub Actions coverage setup.

Changes:
- Runs coverage before uploading to Codecov.
- Updates Vitest to use Istanbul coverage, matching the installed dependency.
- Ensures coverage/lcov.info is generated for Codecov.

Local checks completed:
- npm test passed
- npm run coverage completed successfully