### PR TITLE
Add analytics data API for Sprint 4

### DIFF
--- a/ANALYTICS_DATA_FORMAT.md
+++ b/ANALYTICS_DATA_FORMAT.md
@@ -1,0 +1,16 @@
+\# Sprint 4 Analytics Data Format
+
+
+
+\## Person 1: Analytics Backend / Data Foundation
+
+
+
+The analytics data is provided by:
+
+
+
+```text
+
+GET /api/analytics
+

--- a/functions/api/analytics.js
+++ b/functions/api/analytics.js
@@ -1,0 +1,209 @@
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}
+
+/* =========================
+   ANALYTICS HELPERS
+========================= */
+
+const VALID_ORDER_STATUSES = ["received", "preparing", "ready", "complete"];
+
+function isValidPaidOrder(order) {
+  return (
+    order &&
+    order.payment_status === "paid" &&
+    VALID_ORDER_STATUSES.includes(order.status)
+  );
+}
+
+function safeNumber(value) {
+  const numberValue = Number(value);
+
+  if (Number.isNaN(numberValue)) {
+    return 0;
+  }
+
+  return numberValue;
+}
+
+function calculateOrderTotal(orderItems) {
+  if (!Array.isArray(orderItems)) {
+    return 0;
+  }
+
+  return orderItems.reduce((total, item) => {
+    const quantity = safeNumber(item.quantity);
+    const price = safeNumber(item.price);
+
+    return total + quantity * price;
+  }, 0);
+}
+
+function getOrderDate(createdAt) {
+  if (!createdAt) {
+    return null;
+  }
+
+  return new Date(createdAt).toISOString().split("T")[0];
+}
+
+function getOrderTime(createdAt) {
+  if (!createdAt) {
+    return null;
+  }
+
+  return new Date(createdAt).toISOString().split("T")[1].slice(0, 8);
+}
+
+function getOrderHour(createdAt) {
+  if (!createdAt) {
+    return null;
+  }
+
+  return new Date(createdAt).getHours();
+}
+
+function prepareAnalyticsOrder(order) {
+  const orderItems = Array.isArray(order.order_items) ? order.order_items : [];
+  const calculatedTotal = calculateOrderTotal(orderItems);
+
+  return {
+    order_id: order.id,
+    vendor_id: order.vendor_id,
+    vendor_name: order.vendors?.business_name || "Unknown Vendor",
+
+    order_status: order.status,
+    payment_status: order.payment_status,
+    payment_provider: order.payment_provider || null,
+    transaction_id: order.transaction_id || null,
+
+    created_at: order.created_at,
+    paid_at: order.paid_at || null,
+    order_date: getOrderDate(order.created_at),
+    order_time: getOrderTime(order.created_at),
+    order_hour: getOrderHour(order.created_at),
+
+    order_total: calculatedTotal,
+    payment_amount: order.payment_amount ? safeNumber(order.payment_amount) : null,
+
+    item_count: orderItems.reduce((total, item) => {
+      return total + safeNumber(item.quantity);
+    }, 0),
+
+    items: orderItems.map((item) => {
+      return {
+        item_id: item.menu_item_id,
+        item_name: item.menu_items?.name || "Unknown Item",
+        quantity: safeNumber(item.quantity),
+        price: safeNumber(item.price),
+        line_total: safeNumber(item.quantity) * safeNumber(item.price),
+      };
+    }),
+  };
+}
+
+async function fetchPaidOrdersFromSupabase(env) {
+  const selectQuery = [
+    "id",
+    "student_id",
+    "vendor_id",
+    "status",
+    "created_at",
+    "paid_at",
+    "payment_status",
+    "payment_provider",
+    "payment_amount",
+    "transaction_id",
+    "vendors(id,business_name)",
+    "order_items(id,menu_item_id,quantity,price,menu_items(id,name,price))",
+  ].join(",");
+
+  const url =
+    `${env.SUPABASE_URL}/rest/v1/orders` +
+    `?select=${encodeURIComponent(selectQuery)}` +
+    `&payment_status=eq.paid` +
+    `&order=created_at.desc`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Could not fetch analytics data: ${errorText}`);
+  }
+
+  return response.json();
+}
+
+/* =========================
+   API HANDLER
+========================= */
+
+export async function onRequest(context) {
+  const { request, env } = context;
+
+  if (request.method === "OPTIONS") {
+    return jsonResponse({ ok: true });
+  }
+
+  if (request.method !== "GET") {
+    return jsonResponse(
+      {
+        success: false,
+        message: "Method not allowed. Use GET.",
+      },
+      405
+    );
+  }
+
+  try {
+    if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+      console.error("Missing Supabase environment variables.");
+
+      return jsonResponse(
+        {
+          success: false,
+          message: "Server configuration error.",
+        },
+        500
+      );
+    }
+
+    const orders = await fetchPaidOrdersFromSupabase(env);
+
+    const analyticsOrders = orders
+      .filter(isValidPaidOrder)
+      .map(prepareAnalyticsOrder);
+
+    return jsonResponse({
+      success: true,
+      message: "Analytics data loaded successfully.",
+      count: analyticsOrders.length,
+      data: analyticsOrders,
+    });
+  } catch (error) {
+    console.error("Analytics API error:", error);
+
+    return jsonResponse(
+      {
+        success: false,
+        message: "Could not load analytics data.",
+      },
+      500
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 
     "test:payment": "vitest run tests/payment-api.test.js",
     "test:notify": "vitest run tests/payfast-notify.test.js",
+    "test:analytics": "vitest run tests/analytics-api.test.js",
 
     "test:login": "vitest run tests/login.test.js",
     "test:register": "vitest run tests/register.test.js",

--- a/tests/analytics-api.test.js
+++ b/tests/analytics-api.test.js
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { onRequest } from "../functions/api/analytics.js";
+
+const validEnv = {
+  SUPABASE_URL: "https://test-project.supabase.co",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+};
+
+function createRequest(method = "GET") {
+  return new Request("https://test.local/api/analytics", {
+    method,
+  });
+}
+
+async function callAnalyticsApi(env = validEnv, method = "GET") {
+  const response = await onRequest({
+    request: createRequest(method),
+    env,
+  });
+
+  const data = await response.json();
+
+  return {
+    response,
+    data,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("analytics API", () => {
+  test("returns only valid paid orders with clean analytics data", async () => {
+    const paidOrder = {
+      id: "order-1",
+      student_id: "student-1",
+      vendor_id: "vendor-1",
+      status: "received",
+      created_at: "2026-05-11T12:30:00.000Z",
+      paid_at: "2026-05-11T12:31:00.000Z",
+      payment_status: "paid",
+      payment_provider: "payfast_sandbox",
+      payment_amount: 65.5,
+      transaction_id: "TXN-123",
+      vendors: {
+        id: "vendor-1",
+        business_name: "Campus Café",
+      },
+      order_items: [
+        {
+          id: "item-row-1",
+          menu_item_id: "menu-item-1",
+          quantity: 2,
+          price: 25,
+          menu_items: {
+            id: "menu-item-1",
+            name: "Burger",
+            price: 25,
+          },
+        },
+        {
+          id: "item-row-2",
+          menu_item_id: "menu-item-2",
+          quantity: 1,
+          price: 15.5,
+          menu_items: {
+            id: "menu-item-2",
+            name: "Juice",
+            price: 15.5,
+          },
+        },
+      ],
+    };
+
+    const unpaidOrder = {
+      id: "order-2",
+      vendor_id: "vendor-1",
+      status: "payment_pending",
+      created_at: "2026-05-11T13:00:00.000Z",
+      payment_status: "unpaid",
+      vendors: {
+        business_name: "Campus Café",
+      },
+      order_items: [],
+    };
+
+    const failedPaidOrder = {
+      id: "order-3",
+      vendor_id: "vendor-2",
+      status: "payment_failed",
+      created_at: "2026-05-11T14:00:00.000Z",
+      payment_status: "paid",
+      vendors: {
+        business_name: "Snack Shack",
+      },
+      order_items: [],
+    };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([paidOrder, unpaidOrder, failedPaidOrder]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    const { response, data } = await callAnalyticsApi();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.count).toBe(1);
+
+    expect(data.data[0]).toMatchObject({
+      order_id: "order-1",
+      vendor_id: "vendor-1",
+      vendor_name: "Campus Café",
+      order_status: "received",
+      payment_status: "paid",
+      payment_provider: "payfast_sandbox",
+      transaction_id: "TXN-123",
+      created_at: "2026-05-11T12:30:00.000Z",
+      paid_at: "2026-05-11T12:31:00.000Z",
+      order_date: "2026-05-11",
+      order_time: "12:30:00",
+      order_total: 65.5,
+      payment_amount: 65.5,
+      item_count: 3,
+    });
+
+    expect(data.data[0].items).toEqual([
+      {
+        item_id: "menu-item-1",
+        item_name: "Burger",
+        quantity: 2,
+        price: 25,
+        line_total: 50,
+      },
+      {
+        item_id: "menu-item-2",
+        item_name: "Juice",
+        quantity: 1,
+        price: 15.5,
+        line_total: 15.5,
+      },
+    ]);
+  });
+
+  test("calls Supabase with the service role key and paid order filter", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    await callAnalyticsApi();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = globalThis.fetch.mock.calls[0];
+
+    expect(url).toContain(`${validEnv.SUPABASE_URL}/rest/v1/orders`);
+    expect(url).toContain("payment_status=eq.paid");
+
+    expect(options.headers.apikey).toBe(validEnv.SUPABASE_SERVICE_ROLE_KEY);
+    expect(options.headers.Authorization).toBe(
+      `Bearer ${validEnv.SUPABASE_SERVICE_ROLE_KEY}`
+    );
+  });
+
+  test("rejects non-GET requests", async () => {
+    const { response, data } = await callAnalyticsApi(validEnv, "POST");
+
+    expect(response.status).toBe(405);
+    expect(data.success).toBe(false);
+    expect(data.message).toBe("Method not allowed. Use GET.");
+  });
+
+  test("returns server error when Supabase environment variables are missing", async () => {
+    const { response, data } = await callAnalyticsApi({}, "GET");
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.message).toBe("Server configuration error.");
+  });
+
+  test("returns error response when Supabase request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Database error", {
+        status: 500,
+      })
+    );
+
+    const { response, data } = await callAnalyticsApi();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.message).toBe("Could not load analytics data.");
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the Sprint 4 analytics data foundation for Person 1.

## What was added

- Created a new `GET /api/analytics` endpoint.
- Fetches paid order data from Supabase.
- Filters out unpaid, failed, cancelled, and invalid orders.
- Calculates order totals from `order_items`.
- Returns clean analytics fields needed by the dashboard and reports.
- Added automated tests for the analytics API.
- Added an `npm run test:analytics` script.
- Added analytics data format documentation for the rest of the team.

## Files added/updated

- `functions/api/analytics.js`
- `tests/analytics-api.test.js`
- `package.json`
- `ANALYTICS_DATA_FORMAT.md`

## Testing

I tested the analytics API using:

```bash
npm run test:analytics